### PR TITLE
Use all layers of control for Control/Code, Unescape control.code

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -161,5 +161,5 @@ export function createNote(segment: Result) {
 }
 
 export function createCode(control: Control & { profileName?: string }) {
-  return `=========================================================\n# Profile name: ${control.profileName}\n=========================================================\n\n${control.code}`;
+  return `=========================================================\n# Profile name: ${control.profileName}\n=========================================================\n\n${unescape(control.code)}`;
 }

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -100,7 +100,7 @@ export function createDescription(counts: Counts): string {
   } (Can only be tested manually at this time)`;
 }
 
-export function createAssumeRolePolicyDocument(layersOfControl: (Control & { profileName?: string })[], segment: Result): string {
+export function createAssumeRolePolicyDocument(layersOfControl: (Control & { profileInfo?: Record<string, unknown> })[], segment: Result): string {
   const segmentOverview = createNote(segment)
   const code = layersOfControl.map((layer) => createCode(layer)).join("\n\n")
   return `${code}\n\n${segmentOverview}`
@@ -160,6 +160,6 @@ export function createNote(segment: Result) {
   }
 }
 
-export function createCode(control: Control & { profileName?: string }) {
-  return `=========================================================\n# Profile name: ${control.profileName}\n=========================================================\n\n${unescape(control.code)}`;
+export function createCode(control: Control & { profileInfo?: Record<string, unknown> }) {
+  return `=========================================================\n# Profile name: ${control.profileInfo?.name}\n=========================================================\n\n${control.code.replace(/\\\"/, "")}`;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -155,7 +155,7 @@ hdf.profiles.forEach((profile) => {
           },
           Types: [
             `File/Input/${filename}`,
-            `Control/Code/${unescape(control.code).replace(/\//g, "∕")}`,
+            `Control/Code/${layersOfControl.map((layer) => createCode(layer)).join("\n\n").replace(/\//g, "∕")}`,
           ],
         },
         Remediation: {


### PR DESCRIPTION
Completes #6 and closes #5, adds overlaid code information to FindingProviderFields/Control/Code